### PR TITLE
fix(amount): edit get doc block for static analysis

### DIFF
--- a/src/Amount.php
+++ b/src/Amount.php
@@ -115,7 +115,7 @@ class Amount implements Arrayable, Castable, JsonSerializable
     }
 
     /**
-     * @param  null  $decimals
+     * @param  int|null  $decimals
      * @return float
      */
     public function get($decimals = null)


### PR DESCRIPTION
Resolves an issue with static analysis where the`Amount::get()` method expects the $decimals parameter to be null.

```
Parameter #1 $decimals of method Makeable\LaravelCurrencies\Amount::get() expects null, int given.
```